### PR TITLE
Use a homepage that allows both Kube and local dev to resolve files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "private": true,
   "main": "dist/index.js",
+  "homepage": ".",
   "dependencies": {
     "@material-ui/core": "1.5.0",
     "@material-ui/icons": "2.0.2",


### PR DESCRIPTION
- Kube cluster requires /web/onboarding to route traffic
- Local development assumes everything to be hosted at '/'