### PR TITLE
Smokefree API runs under /api

### DIFF
--- a/gql/.graphqlconfig.yaml
+++ b/gql/.graphqlconfig.yaml
@@ -5,6 +5,6 @@ projects:
     extensions:
       endpoints:
         dev:
-          url: 'http://localhost:8086/graphql'
+          url: 'http://localhost:8086/api/graphql'
           headers:
             Authorization: "Bearer ${env:ID_TOKEN}"

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ const App = class App extends React.Component {
             return "Logging in failed: " + (auth && auth.state);
         }
 
-        let uri = process.env.ONBOARDING_API || 'http://localhost:8086/graphql';
+        let uri = process.env.ONBOARDING_API || 'http://localhost:8086/api/graphql';
         console.log('ONBOARDING_API: ' + process.env.ONBOARDING_API);
         console.log('Using Onboarding API at ' + uri);
 


### PR DESCRIPTION
This is to keep parity between running on AWS and running locally. /api will
forward to smokefree-initiative-service, while everything else will end
up on onboarding-web.