### PR TITLE
Clarify the Add Playground dialog

### DIFF
--- a/src/assets/scss/custom/onboarding/_statistics.scss
+++ b/src/assets/scss/custom/onboarding/_statistics.scss
@@ -46,7 +46,7 @@
     }
     .playground-container, .playground-map{
         min-height: 190px !important;
-        height: 190px !important;
+        height: 60vh !important;
         margin: 20px 0;
     }
 }

--- a/src/assets/scss/custom/onboarding/_statistics.scss
+++ b/src/assets/scss/custom/onboarding/_statistics.scss
@@ -49,6 +49,12 @@
         height: 60vh !important;
         margin: 20px 0;
     }
+    .add-playground-pin-title{
+      font-weight: bold;
+      display: block;
+      font-size: 20px;
+      margin-top: 10px;
+    }
 }
 
 .FormDialog-container{

--- a/src/views/Onboarding/Sections/AddPlayground.jsx
+++ b/src/views/Onboarding/Sections/AddPlayground.jsx
@@ -139,6 +139,7 @@ class AddPlayground extends React.Component {
                     </Button>
                 }
                 <Dialog
+                    fullScreen
                     open={this.state.open}
                     onClose={this.handleClose}
                     aria-labelledby="form-dialog-title"
@@ -147,7 +148,7 @@ class AddPlayground extends React.Component {
                     <DialogTitle id="form-dialog-title">Voeg een speeltuin toe</DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Je staat op het punt om een speeltuin toe te voegen. We willen alleen nog van je weten wat de naam is van deze speeltuin.
+                            Je staat op het punt om een speeltuin toe te voegen. We willen alleen nog van je weten wat de naam is van deze speeltuin. Plaats alstublieft pin op de kaart:
                         </DialogContentText>
                         <PlaygroundMap
                             className={"playground-container"}

--- a/src/views/Onboarding/Sections/AddPlayground.jsx
+++ b/src/views/Onboarding/Sections/AddPlayground.jsx
@@ -148,7 +148,8 @@ class AddPlayground extends React.Component {
                     <DialogTitle id="form-dialog-title">Voeg een speeltuin toe</DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Je staat op het punt om een speeltuin toe te voegen. We willen alleen nog van je weten wat de naam is van deze speeltuin. Plaats alstublieft pin op de kaart:
+                            Je staat op het punt om een speeltuin toe te voegen. We willen alleen nog van je weten wat de naam is van deze speeltuin.
+                            <span className={"add-playground-pin-title"}>Plaats alstublieft pin op de kaart:</span>
                         </DialogContentText>
                         <PlaygroundMap
                             className={"playground-container"}


### PR DESCRIPTION
Explicitly tell the user to place the pin on the map
Enable FullScreen size of the pop-up dialog

![image](https://user-images.githubusercontent.com/6214770/54907829-89f60080-4ef7-11e9-8840-271d7f879ea2.png)
