### PR TITLE
Remove unnecessary business pin points from playground map

### DIFF
--- a/src/views/Onboarding/Sections/PlaygroundMap.jsx
+++ b/src/views/Onboarding/Sections/PlaygroundMap.jsx
@@ -74,7 +74,7 @@ const PlaygroundMapImpl = compose(
                     props.onMapClick(e);
                 }
             }}
-            defaultOptions={{disableDefaultUI: true}}
+            defaultOptions={{disableDefaultUI: true, styles: [{ elementType: "labels", featureType: "poi", stylers: [{ visibility: "off" }] }]}}
         >
 
             <MarkerClusterer


### PR DESCRIPTION
https://github.com/local-motion/product/issues/259

Before:
![image](https://user-images.githubusercontent.com/6214770/55092404-9c249a00-50c3-11e9-9d0a-366a0bc78ab8.png)

After:
![image](https://user-images.githubusercontent.com/6214770/55092564-d42bdd00-50c3-11e9-8233-fbbaca241278.png)
